### PR TITLE
remove unknown rubocop parameter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,5 +19,4 @@ Style/BracesAroundHashParameters:
 
 Metrics/LineLength:
   Max: 120
-  AllowHereDoc: true
   AllowURI: true


### PR DESCRIPTION
Silence the warnings

[ci skip]