### PR TITLE
Build & Run Phases for Submission Runners

### DIFF
--- a/app/jobs/run_submission_job.rb
+++ b/app/jobs/run_submission_job.rb
@@ -1,9 +1,30 @@
+require 'submission_runners'
+
 class RunSubmissionJob < ApplicationJob
   queue_as :default
 
   def perform(submission_id)
-    submission = Submission.find_by_id(submission_id)
-    # Run the submission inside docker
-    submission.submission_results.create!
+    submission = Submission.find_by_id!(submission_id)
+    runner     = SubmissionRunners.runner_for_submission(submission)
+
+    submission_result = SubmissionResult.create!({
+      submission_id: submission.id,
+    })
+
+    runner.call
+
+    if runner.run_succeeded?
+      submission_result.passed = true
+    else
+      runner.errors.each do |runner_phase, error|
+        SubmissionResultNotification.create!({
+          submission_result_id: submission_result.id,
+          runner_phase:         runner_phase.to_s,
+          message:              error.message,
+        })
+      end
+    end
+
+    submission_result.save!
   end
 end

--- a/app/jobs/run_submission_job.rb
+++ b/app/jobs/run_submission_job.rb
@@ -5,26 +5,26 @@ class RunSubmissionJob < ApplicationJob
 
   def perform(submission_id)
     submission = Submission.find_by_id!(submission_id)
-    runner     = SubmissionRunners.runner_for_submission(submission)
 
     submission_result = SubmissionResult.create!({
       submission_id: submission.id,
     })
 
-    runner.call
+    # runner = SubmissionRunners.runner_for_submission(submission)
+    # runner.call
 
-    if runner.run_succeeded?
-      submission_result.passed = true
-    else
-      runner.errors.each do |runner_phase, error|
-        SubmissionResultNotification.create!({
-          submission_result_id: submission_result.id,
-          runner_phase:         runner_phase.to_s,
-          message:              error.message,
-        })
-      end
-    end
+    # if runner.run_succeeded?
+    #   submission_result.passed = true
+    # else
+    #   runner.errors.each do |runner_phase, error|
+    #     SubmissionResultNotification.create!({
+    #       submission_result_id: submission_result.id,
+    #       runner_phase:         runner_phase.to_s,
+    #       message:              error.message,
+    #     })
+    #   end
+    # end
 
-    submission_result.save!
+    # submission_result.save!
   end
 end

--- a/db/migrate/20170520201414_add_submission_result_notifications.rb
+++ b/db/migrate/20170520201414_add_submission_result_notifications.rb
@@ -1,0 +1,11 @@
+class AddSubmissionResultNotifications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :submission_result_notifications do |t|
+      t.string :runner_phase
+      t.string :message
+      t.references :submission_result, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170520182134) do
+ActiveRecord::Schema.define(version: 20170520201414) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "username"
@@ -59,6 +59,15 @@ ActiveRecord::Schema.define(version: 20170520182134) do
     t.boolean "ignore_case"
     t.string "whitespace_rule", default: "plain diff"
     t.index ["contest_id"], name: "index_problems_on_contest_id"
+  end
+
+  create_table "submission_result_notifications", force: :cascade do |t|
+    t.string "runner_phase"
+    t.string "message"
+    t.integer "submission_result_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["submission_result_id"], name: "index_submission_result_notifications_on_submission_result_id"
   end
 
   create_table "submission_results", force: :cascade do |t|

--- a/lib/submission_runners.rb
+++ b/lib/submission_runners.rb
@@ -1,0 +1,14 @@
+module SubmissionRunners
+  def self.runner_for_submission(submission)
+    extension    = submission.source_file.extname
+    runner_class = language_extension_map[extension]
+
+    runner_class.new(submission)
+  end
+
+  def self.language_extension_map
+    {
+      '.java' => Java,
+    }
+  end
+end

--- a/lib/submission_runners/base.rb
+++ b/lib/submission_runners/base.rb
@@ -14,6 +14,8 @@ module SubmissionRunners
       run_phase(:build) && run_phase(:run)
     end
 
+    private
+
     def run_phase(phase)
       result = send(phase)
 
@@ -23,8 +25,6 @@ module SubmissionRunners
 
       result.success?
     end
-
-    private
 
     def docker_run(*command, **options)
       command = [
@@ -57,6 +57,14 @@ module SubmissionRunners
 
     def problem_timeout
       submission.problem_timeout || 30.seconds
+    end
+
+    def source_file
+      submission.source_file
+    end
+
+    def input_file
+      submission.problem_input_file
     end
 
     def container_user # should probably be overrideable, but this is a good default

--- a/lib/submission_runners/base.rb
+++ b/lib/submission_runners/base.rb
@@ -2,12 +2,12 @@ require 'tty/command'
 
 module SubmissionRunners
   class Base
-    attr_reader :submission, :errors, :output
+    attr_reader :submission, :errors
+    attr_accessor :result
 
     def initialize(submission)
       @submission = submission
       @errors     = {}
-      @output     = ""
     end
 
     def submission_dir
@@ -18,10 +18,16 @@ module SubmissionRunners
       submission.problem_timeout || 30.seconds
     end
 
-    def run_command(command, **options)
-      TTY::Command.
-        new(printer: :null).
-        run(command, **options)
+    def run_command(phase, command_pieces, **options)
+      begin
+        self.result = TTY::Command.
+          new(printer: :null).
+          run(*command_pieces, **options)
+      rescue TTY::Command::ExitError => error
+        errors[phase] = error
+      end
+
+      errors.empty?
     end
 
     def build_container

--- a/lib/submission_runners/base.rb
+++ b/lib/submission_runners/base.rb
@@ -30,20 +30,8 @@ module SubmissionRunners
       errors.empty?
     end
 
-    def build_container
-      "#{container_prefix}-build-#{container_suffix}"
-    end
-
-    def run_container
-      "#{container_prefix}-run-#{container_suffix}"
-    end
-
-    def container_prefix
-      self.class.name.demodulize.underscore
-    end
-
-    def container_suffix
-      submission.id.to_s
+    def container
+      "#{self.class.name.demodulize.underscore}-#{submission.id}"
     end
   end
 end

--- a/lib/submission_runners/java.rb
+++ b/lib/submission_runners/java.rb
@@ -19,11 +19,12 @@ module SubmissionRunners
 
       command_pieces = [
         "docker", "run",
-        "--name", build_container,
+        "--name", container,
         "--volume", "#{submission_dir}:/workspace",
         "--workdir", "/workspace",
         "--user", container_user,
         "--rm",
+        "--attach", "STDIN",
         "--attach", "STDOUT",
         "--attach", "STDERR",
         "--interactive",
@@ -41,7 +42,7 @@ module SubmissionRunners
     def run
       command_pieces = [
         "docker", "run",
-        "--name", run_container,
+        "--name", container,
         "--volume", "#{submission_dir}:/workspace",
         "--workdir", "/workspace",
         "--user", container_user,

--- a/lib/submission_runners/java.rb
+++ b/lib/submission_runners/java.rb
@@ -55,14 +55,16 @@ module SubmissionRunners
       ]
 
       input = StringIO.new
+
       input.write(input_file.read)
+      input.rewind
 
       run_command(
         :run,
         command_pieces,
         timeout: problem_timeout,
         chdir: submission_dir,
-        in: input.tap(&:rewind),
+        in: input,
       )
     end
 

--- a/lib/submission_runners/java.rb
+++ b/lib/submission_runners/java.rb
@@ -29,14 +29,6 @@ module SubmissionRunners
       "nobody"
     end
 
-    def source_file
-      submission.source_file
-    end
-
-    def input_file
-      submission.problem_input_file
-    end
-
     def java_class
       submission.problem_name
     end

--- a/spec/lib/submission_runner_spec.rb
+++ b/spec/lib/submission_runner_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 require 'submission_runners/java'
 require 'fixtures/submission_runners/java/submissions'
 
-RSpec.describe SubmissionRunners::Java do
-  describe "#do_the_thing" do
+RSpec.describe SubmissionRunners::Java, docker: true do
+  describe "#call" do
     let(:output_fixture) do
       Pathname.new(Rails.root).join("spec/fixtures/submission_runners/java/Output")
     end
@@ -20,19 +20,27 @@ RSpec.describe SubmissionRunners::Java do
       end
     end
 
-    xcontext "java code that will generate compiler errors" do
+    context "java code that will generate compiler errors" do
       let(:submission) { DoesntCompile }
 
-      it "has errors" do
-        expect(runner.errors).to_not be_empty
+      it "has build errors" do
+        expect(runner.errors[:build]).to_not be_nil
+      end
+
+      it "doesn't have run errors" do
+        expect(runner.errors[:run]).to be_nil
       end
     end
 
-    xcontext "java code that will generate runtime errors" do
+    context "java code that will generate runtime errors" do
       let(:submission) { CompilesDoesntRun }
 
-      it "has errors" do
-        expect(runner.errors).to_not be_empty
+      it "doesn't have build errors" do
+        expect(runner.errors[:build]).to be_nil
+      end
+
+      it "has run errors" do
+        expect(runner.errors[:run]).to_not be_nil
       end
     end
   end

--- a/spec/lib/submission_runners/java_spec.rb
+++ b/spec/lib/submission_runners/java_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'submission_runners/java'
 require 'fixtures/submission_runners/java/submissions'
 
 RSpec.describe SubmissionRunners::Java, docker: true do


### PR DESCRIPTION
We need to let participants that their submissions failed differently if it suffers a build failure than if it suffers a run failure. To do so, we've created the concept of "phases", and provided some structure around them.

We've also created SubmissionResultNotification to provide said messages to participants (& yes, at this point, we're basically building CI job pages). We think a new model is better than having several more attributes on SubmissionResult that are only used for failed submissions.