### PR TITLE
Use local tmp directory for test files

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,5 +44,5 @@ Rails.application.configure do
   config.active_job.queue_adapter = :test
 
   # Move files into tmp
-  config.files_base = Pathname.new Dir::Tmpname.tmpdir
+  config.files_base = Pathname(__FILE__) + '../../../tmp/test_files'
 end


### PR DESCRIPTION
Using Dir.tmpdir for base_files means that Docker tests that use real
Submissions fail on OS X due to permissions.

Moving it under tmp/test_files makes Docker.app happy and means it's
easier to find files when things fail.