### PR TITLE
Reduces duplicate contest creation

### DIFF
--- a/app/controllers/admin/contests_controller.rb
+++ b/app/controllers/admin/contests_controller.rb
@@ -21,8 +21,9 @@ module Admin
     def start
       @contest = Contest.instance
 
-      @contest.update_attributes started_at: Time.current.utc
+      @contest.start
 
+      @contest.save
       flash[:success] = "The contest has started"
 
       redirect_to admin_contest_path

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -5,6 +5,10 @@ class Contest < ApplicationRecord
   def self.instance
     order(:created_at).reverse.first
   end
+
+  def start(time: Time.current.utc)
+    self.started_at = time
+  end
 end
 
 # == Schema Information

--- a/db/migrate/20170521150912_add_username_index_to_account.rb
+++ b/db/migrate/20170521150912_add_username_index_to_account.rb
@@ -1,0 +1,6 @@
+class AddUsernameIndexToAccount < ActiveRecord::Migration[5.1]
+  def change
+    add_index :accounts, :username, unique: true
+    add_index :accounts, [:username, :password]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170520201414) do
+ActiveRecord::Schema.define(version: 20170521150912) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "username"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20170520201414) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["contest_id"], name: "index_accounts_on_contest_id"
+    t.index ["username", "password"], name: "index_accounts_on_username_and_password"
+    t.index ["username"], name: "index_accounts_on_username", unique: true
   end
 
   create_table "administrators", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,12 @@
-password = TokenPhrase.generate
+Contest.create! unless Contest.instance
 
-Contest.create!
+unless Account.where(admin: true).exists?
+  password = TokenPhrase.generate
 
-Account.create(username: "admin", password: password, admin: true, contest: Contest.instance)
+  Account.create(username: "admin", password: password, admin: true, contest: Contest.instance)
+else
+  password = Account.find_by(username: "admin", admin: true).password
+end
+
 puts "SAVE YOUR PASSWORD AND YOUR USERNAME :"
 puts "admin:#{password}"

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -1,18 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe SubmissionsController, type: :controller do
-  before(:all) do
-    @contest = Contest.create
-    @account = Account.create!(contest: @contest, username: 'test', password: 'test')
-  end
-
   # GET new just displays a view.
   # Use view or request specs
 
-  let!(:contest) { @contest }
+  let(:contest) { Contest.instance }
   let!(:team)    { contest.teams.create }
+  let(:account) { Account.find_by(admin: true) }
 
-  let(:valid_session) { { current_account_id: @account.id } }
+  let(:valid_session) { { current_account_id: account.id } }
 
   describe 'POST create' do
     FIXTURE_NAME = 'Submission.java'

--- a/spec/features/account_authentication_spec.rb
+++ b/spec/features/account_authentication_spec.rb
@@ -2,21 +2,21 @@ require 'rails_helper'
 
 RSpec.feature 'Account Authentication', type: :feature do
   scenario 'account login successfully' do
-    Account.create!(username: "account", password: "account", contest: Contest.create!)
+    Account.create!(username: "account", password: "account", contest: Contest.instance)
     visit root_path
     login("account", "account")
     expect(page).to have_content "You have successfully logged in"
   end
 
   scenario 'account login unsuccessfully' do
-    Account.create!(username: "account", password: "accountddd", contest: Contest.create!)
+    Account.create!(username: "account", password: "accountddd", contest: Contest.instance)
     visit root_path
     login("account", "account")
     expect(page).to have_content "You have entered the wrong credentials"
   end
 
   scenario 'account logout successfully' do
-    Account.create!(username: "account", password: "account", contest: Contest.create!)
+    Account.create!(username: "account", password: "account", contest: Contest.instance)
     visit root_path
     login("account", "account")
     click_link "Logout"

--- a/spec/features/admin_authentication_spec.rb
+++ b/spec/features/admin_authentication_spec.rb
@@ -2,21 +2,21 @@ require 'rails_helper'
 
 RSpec.feature 'Admin Authentication', type: :feature do
   scenario 'admin login successfully' do
-    Account.create!(username: "someone@example.tld", password: "somepassword", admin: true, contest: Contest.create!)
+    Account.create!(username: "someone@example.tld", password: "somepassword", admin: true, contest: Contest.instance)
     visit root_path
     login("someone@example.tld", "somepassword")
     expect(page).to have_content "You have successfully logged in"
   end
 
   scenario 'admin login unsuccessfully' do
-    Account.create!(username: "someone@example.tld", password: "somepassword", admin: true, contest: Contest.create!)
+    Account.create!(username: "someone@example.tld", password: "somepassword", admin: true, contest: Contest.instance)
     visit root_path
     login("someone@example.tld", "someotherpassword")
     expect(page).to have_content "You have entered the wrong credentials"
   end
 
   scenario 'admin logout successfully' do
-    Account.create!(username: "someone@example.tld", password: "somepassword", admin: true, contest: Contest.create!)
+    Account.create!(username: "someone@example.tld", password: "somepassword", admin: true, contest: Contest.instance)
     visit root_path
     login("someone@example.tld", "somepassword")
     click_link "Logout"

--- a/spec/features/admin_cruds_teams_spec.rb
+++ b/spec/features/admin_cruds_teams_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'administrator can create teams', type: :feature do
       click_on "Add New Team"
 
       fill_in "Name", with: t[:name]
-      fill_in "Username", with: t[:user]
+      fill_in "Username", with: t[:username]
 
       click_on "Create Team"
     end

--- a/spec/features/admin_scoreboard_spec.rb
+++ b/spec/features/admin_scoreboard_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature 'Admin scoreboard', type: :feature do
-  let(:contest) { Contest.create!(started_at: Time.now) }
+  let(:contest) { Contest.instance }
+
+  before do
+    contest.start
+    contest.save
+  end
 
   scenario 'admin scoreboard is not accessible to participants' do
     visit admin_contest_scoreboard_path(contest)

--- a/spec/jobs/run_submission_job_spec.rb
+++ b/spec/jobs/run_submission_job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe RunSubmissionJob, type: :job do
   it 'creates a submission result' do
-    contest    = Contest.create
+    contest    = Contest.instance
     team       = Team.create(contest: contest)
     problem    = Problem.create(contest: contest)
     submission = Submission.create(problem: problem, team: team)

--- a/spec/lib/submission_runners/java_spec.rb
+++ b/spec/lib/submission_runners/java_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SubmissionRunners::Java, type: :docker do
   describe "#call" do
-    let(:contest) { Contest.create! }
+    let(:contest) { Contest.instance }
     let(:team)    { contest.teams.create! }
     let(:problem) do
       p = Problem.new({

--- a/spec/models/contest_spec.rb
+++ b/spec/models/contest_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Contest, type: :model do
   it "has many problems" do
-    contest = Contest.create!(name: "contest")
+    contest = Contest.instance
     contest.problems.create
     contest.problems.create
     expect(contest.problems.count).to be 2
   end
 
   it "has many teams" do
-    contest = Contest.create!(name: "contest")
+    contest = Contest.instance
     contest.teams.create
     contest.teams.create
     expect(contest.teams.count).to be 2

--- a/spec/models/problem_spec.rb
+++ b/spec/models/problem_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Problem, type: :model do
   describe "#uploaded_files_dir" do
     let(:problem) do
       Problem.create!({
-        contest: Contest.create!
+        contest: Contest.instance
       })
     end
 
@@ -13,7 +13,7 @@ RSpec.describe Problem, type: :model do
   end
 
   it "has many submissions" do
-    contest = Contest.create!(name: "contest")
+    contest = Contest.instance
     problem = Problem.create!(contest: contest)
     team = Team.create!(contest: contest)
     problem.submissions.create!(team: team)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Submission, type: :model do
   describe "#uploaded_files_dir" do
-    let(:contest) { Contest.create! }
+    let(:contest) { Contest.instance }
     let(:submission) do
       Submission.create!({
         team: Team.create!({
@@ -19,7 +19,7 @@ RSpec.describe Submission, type: :model do
     end
 
     it 'it has many submission results' do
-      contest = Contest.create!(name: "contest")
+      contest = Contest.instance
       problem = Problem.create!(contest: contest)
       team = Team.create!(contest: contest)
       submission = problem.submissions.create!(team: team)

--- a/spec/models/team_score_service_spec.rb
+++ b/spec/models/team_score_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe TeamScoreService, type: :model do
-  let(:contest) { Contest.create! }
+  let(:contest) { Contest.instance }
   let(:team) { Team.create!(contest: contest) }
 
   describe '#call' do
@@ -32,7 +32,7 @@ RSpec.describe TeamScoreService, type: :model do
 
     context 'with multiple contests' do
       it 'returns the score for a specific contest' do
-        other_contest = Contest.create!
+        other_contest = Contest.instance
 
         problem = Problem.create!(contest: contest)
         other_problem = Problem.create!(contest: other_contest)

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Team, type: :model do
   it 'it has many submissions' do
-    contest = Contest.create!(name: "contest")
-    problem = Problem.create!(contest: contest)
-    team = Team.create!(contest: contest)
+    contest = Contest.instance
+    problem = contest.problems.create!
+    team = contest.teams.create!
     submission = problem.submissions.create!(team: team)
     submission = problem.submissions.create!(team: team)
     expect(team.submissions.count).to be 2

--- a/spec/models/team_time_service_spec.rb
+++ b/spec/models/team_time_service_spec.rb
@@ -1,8 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe TeamTimeService, type: :model do
-  let(:contest) { Contest.create!(started_at: Time.now) }
+  let(:contest) { Contest.instance }
   let(:team) { Team.create!(contest: contest) }
+
+  before do
+    contest.start
+    contest.save!
+  end
 
   describe '#call' do
     context 'without submissions' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 require 'pry'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -26,6 +27,9 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
+
+# Load our seed data
+require_relative '../db/seeds'
 
 RSpec.configure do |config|
   # Support modules

--- a/spec/support/a_configured_context.rb
+++ b/spec/support/a_configured_context.rb
@@ -1,5 +1,5 @@
 shared_context "a configured contest" do
   before do
-    Contest.create! name: 'A Test Contest'
+    Contest.instance
   end
 end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -1,5 +1,5 @@
 shared_context "an authorized admin" do
-  let(:admin) { Account.create! username: "proctor", password: 'asdf123', admin: true, contest: Contest.create! }
+  let(:admin) { Account.create! username: "proctor", password: 'asdf123', admin: true, contest: Contest.instance }
 
   before do
     visit "/login"


### PR DESCRIPTION
This update the seeds to be idempotent, and chases through the specs to remove cases where a new contest is created instead of using our singleton