### PR TITLE
Fix files_base name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module Milton
 
     config.active_job.queue_adapter = :sidekiq
 
-    config.files_base = Pathname.new "/var/lib/#{self.class.parent.name.underscore}"
+    config.files_base = Pathname.new "/var/lib/milton" # FIXME? Make the dirname dynamic again
 
     config.failed_submission_time_penalty = 20.minutes
     config.page_refresh_interval = 5000


### PR DESCRIPTION
Changing from an application method to a config variable lost the
class name.  Just replace with the string we expect.