### PR TITLE
Fixes the timeout label to seconds

### DIFF
--- a/app/views/admin/problems/_form.html.erb
+++ b/app/views/admin/problems/_form.html.erb
@@ -3,7 +3,7 @@
     <%= form.input :name %>
     <%= form.input :description, type: :text %>
 
-    <%= form.input :timeout, as: :integer, label: 'Timeout (minutes)' %>
+    <%= form.input :timeout, as: :integer, label: 'Timeout (seconds)' %>
 
     <%= form.input :has_input %>
     <%= form.input :auto_judge %>


### PR DESCRIPTION
Update the timeout label to correctly indicate it's in seconds, not minutes