### PR TITLE
Compile cruft has disappeared — C++ S.R. spec

### DIFF
--- a/spec/lib/submission_runners/cpp_spec.rb
+++ b/spec/lib/submission_runners/cpp_spec.rb
@@ -2,20 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SubmissionRunners::Cpp, type: 'docker' do
   describe 'docker command and barebone C++ image' do
-    let(:fixtures) do
-      Pathname.new(Rails.root).
-      join('spec/fixtures/submission_runners/cpp')
-    end
-
-    before { @keep_files = Dir.entries(fixtures) }
-
-    after do
-      compiled = Dir.entries(fixtures) - @keep_files
-      compiled.each do |file|
-        FileUtils.rm File.join(fixtures, file)
-      end
-    end
-
+    let(:fixtures) { Pathname.new(Rails.root).join('spec/fixtures/submission_runners/cpp') }
     let(:contest) { Contest.instance }
     let(:account) { contest.accounts.create! }
 


### PR DESCRIPTION
Seems when I switched testing style over the executable binaries aren't ending up in the fixtures directory for me to clean up.