### PR TITLE
Update Rust version to 1.26.0

### DIFF
--- a/lib/submission_runners/rust.rb
+++ b/lib/submission_runners/rust.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 module SubmissionRunners
   class Rust < Base
     def self.image
-      "rust:1.23.0"
+      "rust:1.26.0"
     end
 
     private


### PR DESCRIPTION
Rust version 1.26.0 has a lot of game changing features including `impl Trait` and the huge benefit of not having to specify references when using matching.  This will make development with Rust easier for those in the competition.